### PR TITLE
feat: rename rpk

### DIFF
--- a/packages/hap-packager/src/plugins/zip-plugin.js
+++ b/packages/hap-packager/src/plugins/zip-plugin.js
@@ -160,14 +160,26 @@ function getDistFilename(options, distExt) {
       )
   }
   let distName
+
+  let { PACKAGE_NAME, PACKAGE_TYPE, NODE_ENV } =
+    globalConfig.launchOptions?.compileOptions?.defineOptions || {}
+  // eg.   packageName.release.production.customName.version.rpk
+  const distNameOption = [
+    PACKAGE_NAME || options.name,
+    PACKAGE_TYPE || flagSign,
+    NODE_ENV,
+    // customName
+    undefined,
+    options.versionName,
+    distExt
+  ]
   if (options.buildNameFormat === compileOptionsMeta.buildNameFormat.ORIGINAL) {
     distName = `${options.name}.${flagSign}.${distExt}`
   } else if (options.buildNameFormat && options.buildNameFormat.startsWith('CUSTOM=')) {
-    const custom = options.buildNameFormat.split('=')[1]
-    distName = `${options.name}.${flagSign}.${custom}.${options.versionName}.${distExt}`
-  } else {
-    distName = `${options.name}.${flagSign}.${options.versionName}.${distExt}`
+    // customName
+    distNameOption[3] = options.buildNameFormat.split('=')[1]
   }
+  distName = distName || distNameOption.filter(Boolean).join('.')
   return distName
 }
 

--- a/packages/hap-packager/src/router/routes.js
+++ b/packages/hap-packager/src/router/routes.js
@@ -131,7 +131,10 @@ async function logger(context, next) {
 async function notify(context, next) {
   const callback = context.conf.options.callback
   if (typeof callback === 'function') {
-    const params = { action: 'runCompile' }
+    const params = {
+      action: 'runCompile',
+      defineOptions: globalConfig.launchOptions?.compileOptions?.defineOptions
+    }
     callback(params)
   }
   context.status = 200

--- a/packages/hap-toolkit/src/gen-webpack-conf/index.js
+++ b/packages/hap-toolkit/src/gen-webpack-conf/index.js
@@ -89,6 +89,7 @@ export default async function genWebpackConf(launchOptions, mode) {
   if (launchOptions.ideConfig && typeof launchOptions.ideConfig.cli === 'object') {
     launchOptions = Object.assign({}, launchOptions.ideConfig.cli, launchOptions)
   }
+  globalConfig.launchOptions = launchOptions
 
   // 源代码目录
   const SRC_DIR = path.resolve(cwd, globalConfig.sourceRoot)


### PR DESCRIPTION
与 IDE 对接的新的 rpk 命名策略：

名字的拼接顺序为   packageName.release.production.customName.version.rpk   

通过以下方式设置 customName 的值：

```js
module.exports = {
  // hap命令构建时的配置参数
  cli: {
    buildNameFormat: 'CUSTOM=production111'
  },
}
```
先从 IDE 传过来的 defineOptions 中获取 PACKAGE_NAME、PACKAGE_TYPE 等参数，缺失的参数由 toolkit 默认填充

然后将各参数拼接成 rpk 名称。