### PR TITLE
fix: init quickapp demo npm registry expired error

### DIFF
--- a/packages/hap-dsl-xvm/templates/app/demo/.npmrc
+++ b/packages/hap-dsl-xvm/templates/app/demo/.npmrc
@@ -1,1 +1,0 @@
-registry="https://registry.npm.taobao.org"


### PR DESCRIPTION
fix: #59 