### PR TITLE
fix widget rpk name error & update lite card custom component path for windows

### DIFF
--- a/packages/hap-packager/src/plugins/zip-plugin.js
+++ b/packages/hap-packager/src/plugins/zip-plugin.js
@@ -316,7 +316,7 @@ ZipPlugin.prototype.apply = function (compiler) {
         const widgets = manifest?.router?.widgets || {}
         Object.keys(widgets).forEach((key) => {
           subpackageOptions.push({
-            name: key.replace('/', '.'),
+            name: key.replaceAll('/', '.'),
             resource: key,
             _widget: true
           })


### PR DESCRIPTION
1. fix widget rpk name error 
2. update lite card custom component path for windows