### PR TITLE
fix: widget subpackage manifest file lost

### DIFF
--- a/packages/hap-packager/src/plugins/zip-plugin.js
+++ b/packages/hap-packager/src/plugins/zip-plugin.js
@@ -318,6 +318,7 @@ ZipPlugin.prototype.apply = function (compiler) {
           subpackageOptions.push({
             name: key.replaceAll('/', '.'),
             resource: key,
+            standalone: true,
             _widget: true
           })
         })


### PR DESCRIPTION
fix: widget subpackage manifest file lost
修复卡片子包manifest文件缺失