### PR TITLE
ide下设置devtool为inline-source-map模式在调试模式下生成的源文件路径不对

### DIFF
--- a/packages/hap-toolkit/src/commands/compile.js
+++ b/packages/hap-toolkit/src/commands/compile.js
@@ -52,7 +52,7 @@ export function compile(platform, mode, watch, options = {}) {
     options.cwd = cwd.charAt(0).toUpperCase() + cwd.slice(1)
   }
   return new Promise(async (resolve, reject) => {
-    // colorconsole.attach(options.log)
+    colorconsole.attach(options.log)
     setCustomConfig(options.cwd)
     // IMPORTANT: set env variables before generating webpack config
     process.env.NODE_PLATFORM = platform
@@ -92,7 +92,6 @@ export function compile(platform, mode, watch, options = {}) {
 
     try {
       const webpackConfig = await genWebpackConf(options, webpackMode)
-      console.log('生成后的配置', JSON.stringify(webpackConfig))
 
       if (watch) {
         const compiler = webpack(webpackConfig)

--- a/packages/hap-toolkit/src/commands/compile.js
+++ b/packages/hap-toolkit/src/commands/compile.js
@@ -46,9 +46,13 @@ showVersion()
  */
 export function compile(platform, mode, watch, options = {}) {
   const errCb = options.onerror
-
+  // window下ide传过来的cwd的盘符是小写，需要转成大写
+  if (options.cwd && options.cwd.charAt(1) === ':') {
+    const cwd = options.cwd
+    options.cwd = cwd.charAt(0).toUpperCase() + cwd.slice(1)
+  }
   return new Promise(async (resolve, reject) => {
-    colorconsole.attach(options.log)
+    // colorconsole.attach(options.log)
     setCustomConfig(options.cwd)
     // IMPORTANT: set env variables before generating webpack config
     process.env.NODE_PLATFORM = platform
@@ -88,6 +92,7 @@ export function compile(platform, mode, watch, options = {}) {
 
     try {
       const webpackConfig = await genWebpackConf(options, webpackMode)
+      console.log('生成后的配置', JSON.stringify(webpackConfig))
 
       if (watch) {
         const compiler = webpack(webpackConfig)

--- a/packages/hap-toolkit/src/gen-webpack-conf/index.js
+++ b/packages/hap-toolkit/src/gen-webpack-conf/index.js
@@ -222,7 +222,7 @@ export default async function genWebpackConf(launchOptions, mode) {
           return `webpack://${namespace}/${resPath.replace(resPath,'.'+src)}`
         }
         // 默认返回
-        return `webpack://${namespace}/${resPath}?${info.hash}`;;
+        return `webpack://${namespace}/${resPath}?${info.hash}`
       },
     },
     module: {

--- a/packages/hap-toolkit/src/gen-webpack-conf/index.js
+++ b/packages/hap-toolkit/src/gen-webpack-conf/index.js
@@ -211,7 +211,19 @@ export default async function genWebpackConf(launchOptions, mode) {
       globalObject: 'window',
       path: BUILD_DIR,
       filename: '[name].js',
-      publicPath: '/'
+      publicPath: '/',
+      devtoolModuleFilenameTemplate: (info) => {
+        let resPath = info.resourcePath;
+        let namespace = info.namespace;
+        // ide打包分情况生成的路径不对 "E:\\work\\ide-new\\.build\\electron\\D:\\Users\\Desktop\\1_quickapp-code-21\\src\\app.ux"，需要换成'.src/app.ux'
+        if (resPath.indexOf('electron') !== -1) {
+          // 拿到src及以后的并将\\换成/
+          const src = resPath.split(namespace)[1].replace(/\\/g,'/');
+          return `webpack://${namespace}/${resPath.replace(resPath,'.'+src)}`
+        }
+        // 默认返回
+        return `webpack://${namespace}/${resPath}?${info.hash}`;;
+      },
     },
     module: {
       rules: [

--- a/packages/hap-toolkit/src/gen-webpack-conf/index.js
+++ b/packages/hap-toolkit/src/gen-webpack-conf/index.js
@@ -213,17 +213,17 @@ export default async function genWebpackConf(launchOptions, mode) {
       filename: '[name].js',
       publicPath: '/',
       devtoolModuleFilenameTemplate: (info) => {
-        let resPath = info.resourcePath;
-        let namespace = info.namespace;
+        let resPath = info.resourcePath
+        let namespace = info.namespace
         // ide打包分情况生成的路径不对 "E:\\work\\ide-new\\.build\\electron\\D:\\Users\\Desktop\\1_quickapp-code-21\\src\\app.ux"，需要换成'.src/app.ux'
         if (resPath.indexOf('electron') !== -1) {
           // 拿到src及以后的并将\\换成/
-          const src = resPath.split(namespace)[1].replace(/\\/g,'/');
-          return `webpack://${namespace}/${resPath.replace(resPath,'.'+src)}`
+          const src = resPath.split(namespace)[1].replace(/\\/g, '/')
+          return `webpack://${namespace}/${resPath.replace(resPath, '.' + src)}`
         }
         // 默认返回
         return `webpack://${namespace}/${resPath}?${info.hash}`
-      },
+      }
     },
     module: {
       rules: [


### PR DESCRIPTION
增加webpack的devtoolModuleFilenameTemplate配置修改产出目录