### PR TITLE
游览服务配置反向代理

### DIFF
--- a/packages/hap-server/package.json
+++ b/packages/hap-server/package.json
@@ -44,6 +44,7 @@
     "qr-image": "^3.2.0",
     "qrcode-terminal": "^0.12.0",
     "request": "^2.88.2",
-    "resolve": "^1.22.2"
+    "resolve": "^1.22.2",
+    "koa-proxies": "^0.12.4"
   }
 }

--- a/packages/hap-server/src/preview/create-router.js
+++ b/packages/hap-server/src/preview/create-router.js
@@ -228,6 +228,7 @@ export default async function createRouter(previewTarget) {
         type,
         script,
         scriptNotFound: !scriptExists(script),
+        devtoolUrl: browerOptions.options.devtoolUrl || '',
         webJsUrl: genWebJsUrl(browerOptions.options.version || ctx.conf.options.webVersion), // 更改预览版本号修改为同媒介查询一样的传参方式，同时兼容之前的方式
         language: currentLanguage,
         mediaQueryParams: JSON.stringify(mediaQueryParams) // 传给页面的媒介查询参数

--- a/packages/hap-server/src/preview/views/page.html
+++ b/packages/hap-server/src/preview/views/page.html
@@ -94,6 +94,11 @@
       }
     </script>
     <script type="text/javascript">
+      if (`{{devtoolUrl}}`) {
+        document.write('<script src="{{devtoolUrl}}">\x3C/script>')
+      }
+    </script>
+    <script type="text/javascript">
       var base = '/preview'
       var type = '{{ type }}'
       window.language = `{{language}}`
@@ -102,7 +107,8 @@
         var routeName = '{{ routeName }}'
         Hap.init({
           base,
-          type
+          type,
+          'idePlatform': `{{devtoolUrl}}` ? 'extensionOnline': undefined
         })
       })()
     </script>
@@ -114,7 +120,7 @@
       <p>编译可能存在异常</p>
     </div>
     <script type="text/javascript">
-      if ({{ scriptNotFound }}) {
+      if (`{{ scriptNotFound }}`) {
         // TODO loading
         setTimeout(() => {
           var el = document.getElementById('scriptNotFound')

--- a/packages/hap-server/src/preview/views/page.html
+++ b/packages/hap-server/src/preview/views/page.html
@@ -108,7 +108,7 @@
         Hap.init({
           base,
           type,
-          'idePlatform': `{{devtoolUrl}}` ? 'extensionOnline': undefined
+          idePlatform: `{{devtoolUrl}}` ? 'extensionOnline' : undefined
         })
       })()
     </script>


### PR DESCRIPTION
1：插件的方式调试器模块需要的js需要从插件传给引擎，增加一个devtoolUrl。
2：预览页内部受浏览器同源策略无法发送ajax请求，toolkit内预览服务配置代理转发