### PR TITLE
feat: 轻卡编译器支持 lifecycle params 表达式编译及模板耗时 Feature 校验

### DIFF
--- a/examples/sample/package.json
+++ b/examples/sample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sample",
-  "version": "2.0.9-beta.1",
+  "version": "2.0.9-beta.2",
   "subversion": {
     "toolkit": "0.3.1"
   },
@@ -23,7 +23,7 @@
     "@babel/runtime": "^7.9.6",
     "catching": "^1.0.2",
     "fkill": "^5.3.0",
-    "hap-toolkit": "2.0.9-beta.1",
+    "hap-toolkit": "2.0.9-beta.2",
     "node-fetch": "^2.6.0",
     "npm-run-all": "^4.1.5",
     "qrcode-js": "0.0.2"

--- a/examples/sample/package.json
+++ b/examples/sample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sample",
-  "version": "2.0.9-beta.2",
+  "version": "2.0.9-beta.3",
   "subversion": {
     "toolkit": "0.3.1"
   },
@@ -23,7 +23,7 @@
     "@babel/runtime": "^7.9.6",
     "catching": "^1.0.2",
     "fkill": "^5.3.0",
-    "hap-toolkit": "2.0.9-beta.2",
+    "hap-toolkit": "2.0.9-beta.3",
     "node-fetch": "^2.6.0",
     "npm-run-all": "^4.1.5",
     "qrcode-js": "0.0.2"

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*",
     "test/build/projects/*"
   ],
-  "version": "2.0.9-beta.2"
+  "version": "2.0.9-beta.3"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*",
     "test/build/projects/*"
   ],
-  "version": "2.0.9-beta.1"
+  "version": "2.0.9-beta.2"
 }

--- a/packages/hap-compiler/package.json
+++ b/packages/hap-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hap-toolkit/compiler",
-  "version": "2.0.9-beta.1",
+  "version": "2.0.9-beta.2",
   "description": "compiler of hap-toolkit",
   "engines": {
     "node": ">=14.0.0"
@@ -22,7 +22,7 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "@hap-toolkit/shared-utils": "2.0.9-beta.1",
+    "@hap-toolkit/shared-utils": "2.0.9-beta.2",
     "@jayfate/path": "^0.0.13",
     "css": "^2.2.4",
     "css-what": "^2.1.3",

--- a/packages/hap-compiler/package.json
+++ b/packages/hap-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hap-toolkit/compiler",
-  "version": "2.0.9-beta.2",
+  "version": "2.0.9-beta.3",
   "description": "compiler of hap-toolkit",
   "engines": {
     "node": ">=14.0.0"
@@ -22,7 +22,7 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "@hap-toolkit/shared-utils": "2.0.9-beta.2",
+    "@hap-toolkit/shared-utils": "2.0.9-beta.3",
     "@jayfate/path": "^0.0.13",
     "css": "^2.2.4",
     "css-what": "^2.1.3",

--- a/packages/hap-compiler/src/index.js
+++ b/packages/hap-compiler/src/index.js
@@ -7,11 +7,12 @@
 import parse5 from 'parse5'
 import templater from './template'
 import actioner from './actions'
+import lifecycler from './lifecycle'
 import styler from './style'
 import scripter from './script'
 import { serialize } from './utils'
 
-export { scripter, styler, templater, actioner }
+export { scripter, styler, templater, actioner, lifecycler }
 export * from './style'
 
 /**
@@ -168,5 +169,24 @@ function parseActions(jsonObj) {
   return { parsed }
 }
 
-export { parseFragmentsWithCache, parseTemplate, parseStyle, parseScript, parseActions, serialize }
+/**
+ * 解析 lifecycle
+ * @param {Object} jsonObj - lifecycle对象
+ * @returns {Object}
+ */
+function parseLifecycle(jsonObj) {
+  const { jsonLifecycle } = lifecycler.parse(jsonObj)
+  const parsed = JSON.stringify(jsonLifecycle)
+  return { parsed }
+}
+
+export {
+  parseFragmentsWithCache,
+  parseTemplate,
+  parseStyle,
+  parseScript,
+  parseActions,
+  parseLifecycle,
+  serialize
+}
 export { ENTRY_TYPE, FRAG_TYPE, isEmptyObject } from './utils'

--- a/packages/hap-compiler/src/lifecycle/index.js
+++ b/packages/hap-compiler/src/lifecycle/index.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024-present, the hapjs-platform Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { checkParams } from './validator'
+
+// lifecycle 支持的钩子
+const LIFECYCLE_HOOKS = ['create', 'update']
+
+function parse(lifecycleObj) {
+  /**
+   * "lifecycleObj": {
+      "create": {
+        "params": {
+          "lat": "{{ system.geolocation.getLocation({coordType:'gcj02'}).latitude }}",
+          "deviceType": "{{ system.device.DEVICE_TYPE }}"
+        }
+      },
+      "update": {
+        "params": {
+          "deviceType": "{{ system.device.DEVICE_TYPE }}"
+        }
+      }
+    }
+   */
+  if (lifecycleObj && Object.prototype.toString.call(lifecycleObj) !== '[object Object]') {
+    throw new Error(`<data> lifecycle 必须为 Object 对象`)
+  }
+
+  // 校验 create/update 钩子的 params 合法性
+  LIFECYCLE_HOOKS.forEach((hook) => {
+    const hookObj = lifecycleObj[hook]
+    if (hookObj) {
+      if (Object.prototype.toString.call(hookObj) !== '[object Object]') {
+        throw new Error(`<data> lifecycle.${hook} 必须为 Object 对象`)
+      }
+      checkParams(hookObj.params, 1)
+    }
+  })
+
+  return {
+    jsonLifecycle: lifecycleObj
+  }
+}
+
+export default {
+  parse
+}

--- a/packages/hap-compiler/src/lifecycle/index.js
+++ b/packages/hap-compiler/src/lifecycle/index.js
@@ -5,42 +5,29 @@
 
 import { checkParams } from './validator'
 
-// lifecycle 支持的钩子
-const LIFECYCLE_HOOKS = ['create', 'update']
-
-function parse(lifecycleObj) {
+/**
+ * 解析并校验单个生命周期钩子（create 或 update）对象
+ * @param {Object} hookObj - 形如 { params: { ... } }
+ * @returns {Object}
+ */
+function parse(hookObj) {
   /**
-   * "lifecycleObj": {
-      "create": {
-        "params": {
-          "lat": "{{ system.geolocation.getLocation({coordType:'gcj02'}).latitude }}",
-          "deviceType": "{{ system.device.DEVICE_TYPE }}"
-        }
-      },
-      "update": {
-        "params": {
-          "deviceType": "{{ system.device.DEVICE_TYPE }}"
-        }
+   * "hookObj": {
+      "params": {
+        "lat": "{{ system.geolocation.getLocation({coordType:'gcj02'}).latitude }}",
+        "deviceType": "{{ system.device.DEVICE_TYPE }}"
       }
     }
    */
-  if (lifecycleObj && Object.prototype.toString.call(lifecycleObj) !== '[object Object]') {
-    throw new Error(`<data> lifecycle 必须为 Object 对象`)
+  if (hookObj && Object.prototype.toString.call(hookObj) !== '[object Object]') {
+    throw new Error(`<data> create/update 必须为 Object 对象`)
   }
 
-  // 校验 create/update 钩子的 params 合法性
-  LIFECYCLE_HOOKS.forEach((hook) => {
-    const hookObj = lifecycleObj[hook]
-    if (hookObj) {
-      if (Object.prototype.toString.call(hookObj) !== '[object Object]') {
-        throw new Error(`<data> lifecycle.${hook} 必须为 Object 对象`)
-      }
-      checkParams(hookObj.params, 1)
-    }
-  })
+  // 校验 params 合法性（规则与 actions params 一致）
+  checkParams(hookObj.params, 1)
 
   return {
-    jsonLifecycle: lifecycleObj
+    jsonLifecycle: hookObj
   }
 }
 

--- a/packages/hap-compiler/src/lifecycle/validator.js
+++ b/packages/hap-compiler/src/lifecycle/validator.js
@@ -12,7 +12,7 @@ function isReserved(str) {
 }
 
 /**
- * 校验 lifecycle 中 create/update 的 params 参数
+ * 校验 create/update 的 params 参数
  * 规则与 actions params 一致：只支持一级结构中绑定变量，参数名不能以 $ 开头
  * @param {Object} paramsObj - params 对象
  * @param {number} dep - 当前嵌套深度
@@ -22,11 +22,11 @@ function checkParams(paramsObj, dep) {
 
   Object.keys(paramsObj).forEach((key) => {
     if (isReserved(key)) {
-      throw new Error(`<data> lifecycle 中 params 参数名不能以 “$” 开头`)
+      throw new Error(`<data> create/update 中 params 参数名不能以 “$” 开头`)
     }
 
     if (exp.isExpr(paramsObj[key]) && dep > 1) {
-      throw new Error(`<data> lifecycle 中 params 参数值只支持一级结构中绑定变量`)
+      throw new Error(`<data> create/update 中 params 参数值只支持一级结构中绑定变量`)
     }
 
     checkParams(paramsObj[key], dep + 1)

--- a/packages/hap-compiler/src/lifecycle/validator.js
+++ b/packages/hap-compiler/src/lifecycle/validator.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024-present, the hapjs-platform Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import exp from '../template/exp'
+
+function isReserved(str) {
+  // $开头
+  const c = (str + '').charCodeAt(0)
+  return c === 0x24
+}
+
+/**
+ * 校验 lifecycle 中 create/update 的 params 参数
+ * 规则与 actions params 一致：只支持一级结构中绑定变量，参数名不能以 $ 开头
+ * @param {Object} paramsObj - params 对象
+ * @param {number} dep - 当前嵌套深度
+ */
+function checkParams(paramsObj, dep) {
+  if (!paramsObj || Object.prototype.toString.call(paramsObj) !== '[object Object]') return
+
+  Object.keys(paramsObj).forEach((key) => {
+    if (isReserved(key)) {
+      throw new Error(`<data> lifecycle 中 params 参数名不能以 “$” 开头`)
+    }
+
+    if (exp.isExpr(paramsObj[key]) && dep > 1) {
+      throw new Error(`<data> lifecycle 中 params 参数值只支持一级结构中绑定变量`)
+    }
+
+    checkParams(paramsObj[key], dep + 1)
+  })
+}
+
+export { checkParams }

--- a/packages/hap-compiler/src/template/index.js
+++ b/packages/hap-compiler/src/template/index.js
@@ -438,7 +438,7 @@ function parse(source, options) {
         reason:
           `ERROR: 耗时 Feature "${err.feature}" 不允许在模板表达式中使用。\n` +
           `  原因：模板表达式在 UI 线程同步执行，耗时调用会阻塞渲染。\n` +
-          `  建议：将该调用移到 lifecycle.create.params 或 action params 中。\n` +
+          `  建议：将该调用移到 create.params 或 action params 中。\n` +
           `  表达式：${err.expression}\n  at ${options.filePath}`
       })
     } else if (err.isExpressionError) {

--- a/packages/hap-compiler/src/template/index.js
+++ b/packages/hap-compiler/src/template/index.js
@@ -72,6 +72,9 @@ function traverse(node, output, previousNode, conditionList, options) {
       }
     }
 
+    // 编译期护栏：禁止在模板表达式中调用耗时 Feature
+    validator.checkForbiddenFeature(value, locationInfo, options)
+
     switch (name) {
       case 'id':
         // 保留checkId为兼容原有：新打的RPK包兼容原来的APK平台
@@ -169,6 +172,12 @@ function traverse(node, output, previousNode, conditionList, options) {
       if (child.nodeName.match(/^#/)) {
         // 处理#text节点内容
         if (child.nodeName === '#text' && child.value.trim()) {
+          // 编译期护栏：禁止在模板文本表达式中调用耗时 Feature
+          validator.checkForbiddenFeature(
+            child.value,
+            node.__location ? { line: node.__location.line, column: node.__location.col } : null,
+            options
+          )
           // 兄弟节点不为自闭合标签且非文本标签非原子组件
           if (!preNode || !validator.isSupportedSelfClosing(preNode.nodeName)) {
             if (validator.isNotTextContentAtomic(node.tagName)) {
@@ -420,7 +429,17 @@ function parse(source, options) {
   try {
     traverse(current, output, null, null, options)
   } catch (err) {
-    if (err.isExpressionError) {
+    if (err.isForbiddenFeatureError) {
+      output.log.push({
+        line: err.line,
+        column: err.column,
+        reason:
+          `ERROR: 耗时 Feature "${err.feature}" 不允许在模板表达式中使用。\n` +
+          `  原因：模板表达式在 UI 线程同步执行，耗时调用会阻塞渲染。\n` +
+          `  建议：将该调用移到 lifecycle.create.params 或 action params 中。\n` +
+          `  表达式：${err.expression}\n  at ${options.filePath}`
+      })
+    } else if (err.isExpressionError) {
       output.log.push({
         reason: `ERROR: 表达式解析失败 ${err.message}\n\n> ${err.expression}\n\nat ${options.filePath}`
       })

--- a/packages/hap-compiler/src/template/index.js
+++ b/packages/hap-compiler/src/template/index.js
@@ -433,6 +433,8 @@ function parse(source, options) {
       output.log.push({
         line: err.line,
         column: err.column,
+        // 致命错误：需要中断构建（由 template-loader 上报为 webpack 编译错误）
+        fatal: true,
         reason:
           `ERROR: 耗时 Feature "${err.feature}" 不允许在模板表达式中使用。\n` +
           `  原因：模板表达式在 UI 线程同步执行，耗时调用会阻塞渲染。\n` +

--- a/packages/hap-compiler/src/template/validator.js
+++ b/packages/hap-compiler/src/template/validator.js
@@ -217,7 +217,15 @@ const tagNatives = {
   },
   web: {
     atomic: true,
-    events: ['pagestart', 'pagefinish', 'titlereceive', 'error', 'message', 'progress', 'intercepturl'],
+    events: [
+      'pagestart',
+      'pagefinish',
+      'titlereceive',
+      'error',
+      'message',
+      'progress',
+      'intercepturl'
+    ],
     attrs: {
       src: {},
       trustedurl: {},
@@ -233,7 +241,7 @@ const tagNatives = {
       supportzoom: {
         enum: ['true', 'false']
       },
-      intercepturl:{}
+      intercepturl: {}
     }
   },
   list: {
@@ -1944,6 +1952,52 @@ function checkCustomDirective(name, value, output, node, options) {
   }
 }
 
+// 耗时 Feature 黑名单：这些 Feature 在 UI 线程同步执行会阻塞渲染，
+// 禁止出现在模板表达式中（允许出现在 lifecycle params / action params 中）
+const FORBIDDEN_TEMPLATE_FEATURES = ['system.geolocation.getLocation', 'system.push.subscribe']
+
+// 为每个黑名单 Feature 构建匹配「方法调用」的正则（允许任意参数、段间空白）
+const FORBIDDEN_FEATURE_MATCHERS = FORBIDDEN_TEMPLATE_FEATURES.map((feature) => {
+  const escaped = feature
+    .split('.')
+    .map((seg) => seg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('\\s*\\.\\s*')
+  return {
+    feature,
+    // 前置一个非标识符/非点的边界，避免误匹配 foo.system.geolocation... 之类的其它路径
+    re: new RegExp('(?:^|[^\\w$.])' + escaped + '\\s*\\(')
+  }
+})
+
+/**
+ * 校验模板表达式中是否使用了耗时 Feature（编译期护栏）
+ * 命中黑名单时抛出错误，由 template/index.js 的 parse() 汇入 output.log 报错。
+ * 仅对轻卡（options.lite）生效；lifecycle/action params 不经过模板校验，因此天然放行。
+ * @param  {string} value - 属性值 / 文本内容
+ * @param  {object} locationInfo - 位置信息 {line, column}
+ * @param  {object} options - 编译选项
+ */
+function checkForbiddenFeature(value, locationInfo, options) {
+  if (!options || !options.lite) return
+  if (!value || typeof value !== 'string') return
+  if (!exp.isExpr(value)) return
+
+  for (let i = 0; i < FORBIDDEN_FEATURE_MATCHERS.length; i++) {
+    const { feature, re } = FORBIDDEN_FEATURE_MATCHERS[i]
+    if (re.test(value)) {
+      const err = new Error(`耗时 Feature "${feature}" 不允许在模板表达式中使用`)
+      err.isForbiddenFeatureError = true
+      err.feature = feature
+      err.expression = value.trim()
+      if (locationInfo) {
+        err.line = locationInfo.line
+        err.column = locationInfo.column
+      }
+      throw err
+    }
+  }
+}
+
 /**
  * @param  {string} name
  * @param  {string} value
@@ -2150,6 +2204,7 @@ export default {
   checkEvent,
   checkCustomDirective,
   checkAttr,
+  checkForbiddenFeature,
   checkBuild,
   checkModel,
   isReservedTag,

--- a/packages/hap-compiler/src/template/validator.js
+++ b/packages/hap-compiler/src/template/validator.js
@@ -1954,7 +1954,7 @@ function checkCustomDirective(name, value, output, node, options) {
 
 // 耗时 Feature 黑名单：这些 Feature 在 UI 线程同步执行会阻塞渲染，
 // 禁止出现在模板表达式中（允许出现在 lifecycle params / action params 中）
-const FORBIDDEN_TEMPLATE_FEATURES = ['system.geolocation.getLocation', 'system.push.subscribe']
+const FORBIDDEN_TEMPLATE_FEATURES = ['system.geolocation.getLocation', 'service.push.subscribe']
 
 // 为每个黑名单 Feature 构建匹配「方法调用」的正则（允许任意参数、段间空白）
 const FORBIDDEN_FEATURE_MATCHERS = FORBIDDEN_TEMPLATE_FEATURES.map((feature) => {

--- a/packages/hap-debugger/package.json
+++ b/packages/hap-debugger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hap-toolkit/debugger",
-  "version": "2.0.9-beta.1",
+  "version": "2.0.9-beta.2",
   "description": "@hap-toolkit/debugger",
   "engines": {
     "node": ">=14.0.0"
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "@hap-toolkit/chrome-devtools-frontend": "^1.1.2",
-    "@hap-toolkit/shared-utils": "2.0.9-beta.1",
+    "@hap-toolkit/shared-utils": "2.0.9-beta.2",
     "@jayfate/path": "^0.0.13",
     "@sentry/node": "^5.26.0",
     "adb-commander": "^0.1.9",

--- a/packages/hap-debugger/package.json
+++ b/packages/hap-debugger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hap-toolkit/debugger",
-  "version": "2.0.9-beta.2",
+  "version": "2.0.9-beta.3",
   "description": "@hap-toolkit/debugger",
   "engines": {
     "node": ">=14.0.0"
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "@hap-toolkit/chrome-devtools-frontend": "^1.1.2",
-    "@hap-toolkit/shared-utils": "2.0.9-beta.2",
+    "@hap-toolkit/shared-utils": "2.0.9-beta.3",
     "@jayfate/path": "^0.0.13",
     "@sentry/node": "^5.26.0",
     "adb-commander": "^0.1.9",

--- a/packages/hap-dev-utils/package.json
+++ b/packages/hap-dev-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hap-dev-utils",
-  "version": "2.0.9-beta.2",
+  "version": "2.0.9-beta.3",
   "private": true,
   "description": "utils of development and testing",
   "engines": {

--- a/packages/hap-dev-utils/package.json
+++ b/packages/hap-dev-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hap-dev-utils",
-  "version": "2.0.9-beta.1",
+  "version": "2.0.9-beta.2",
   "private": true,
   "description": "utils of development and testing",
   "engines": {

--- a/packages/hap-dsl-xvm/package.json
+++ b/packages/hap-dsl-xvm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hap-toolkit/dsl-xvm",
-  "version": "2.0.9-beta.1",
+  "version": "2.0.9-beta.2",
   "description": "webpack {loader,plugin} for supporting xvm in quickapp",
   "engines": {
     "node": ">=14.0.0"
@@ -36,9 +36,9 @@
     "!**/.DS_Store"
   ],
   "dependencies": {
-    "@hap-toolkit/compiler": "2.0.9-beta.1",
-    "@hap-toolkit/packager": "2.0.9-beta.1",
-    "@hap-toolkit/shared-utils": "2.0.9-beta.1",
+    "@hap-toolkit/compiler": "2.0.9-beta.2",
+    "@hap-toolkit/packager": "2.0.9-beta.2",
+    "@hap-toolkit/shared-utils": "2.0.9-beta.2",
     "@jayfate/path": "^0.0.13",
     "babel-loader": "^8.1.0",
     "css-loader": "^5.0.1",

--- a/packages/hap-dsl-xvm/package.json
+++ b/packages/hap-dsl-xvm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hap-toolkit/dsl-xvm",
-  "version": "2.0.9-beta.2",
+  "version": "2.0.9-beta.3",
   "description": "webpack {loader,plugin} for supporting xvm in quickapp",
   "engines": {
     "node": ">=14.0.0"
@@ -36,9 +36,9 @@
     "!**/.DS_Store"
   ],
   "dependencies": {
-    "@hap-toolkit/compiler": "2.0.9-beta.2",
-    "@hap-toolkit/packager": "2.0.9-beta.2",
-    "@hap-toolkit/shared-utils": "2.0.9-beta.2",
+    "@hap-toolkit/compiler": "2.0.9-beta.3",
+    "@hap-toolkit/packager": "2.0.9-beta.3",
+    "@hap-toolkit/shared-utils": "2.0.9-beta.3",
     "@jayfate/path": "^0.0.13",
     "babel-loader": "^8.1.0",
     "css-loader": "^5.0.1",

--- a/packages/hap-dsl-xvm/src/loaders/common/utils.js
+++ b/packages/hap-dsl-xvm/src/loaders/common/utils.js
@@ -248,6 +248,7 @@ export const FRAG_TYPE = {
   SCRIPT: 'script',
   DATA: 'data',
   ACTIONS: 'actions',
+  LIFECYCLE: 'lifecycle',
   PROPS: 'props',
   // honor frag
   DATAPP: 'app',

--- a/packages/hap-dsl-xvm/src/loaders/common/utils.js
+++ b/packages/hap-dsl-xvm/src/loaders/common/utils.js
@@ -248,7 +248,8 @@ export const FRAG_TYPE = {
   SCRIPT: 'script',
   DATA: 'data',
   ACTIONS: 'actions',
-  LIFECYCLE: 'lifecycle',
+  CREATE: 'create',
+  UPDATE: 'update',
   PROPS: 'props',
   // honor frag
   DATAPP: 'app',

--- a/packages/hap-dsl-xvm/src/loaders/create-loader.js
+++ b/packages/hap-dsl-xvm/src/loaders/create-loader.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024-present, the hapjs-platform Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { parseLifecycle } from '@hap-toolkit/compiler'
+
+export default function createLoader(source) {
+  let createStr = ''
+  try {
+    const obj = JSON.parse(source)
+    const jsonObj = obj.create || {}
+    const { parsed } = parseLifecycle(jsonObj)
+    createStr = parsed
+  } catch (e) {
+    throw new Error(`${this.resourcePath} 中的 <data> 解析失败，请检查是否为标准的 JSON 格式\n${e}`)
+  }
+  return `module.exports = ${createStr}`
+}

--- a/packages/hap-dsl-xvm/src/loaders/lifecycle-loader.js
+++ b/packages/hap-dsl-xvm/src/loaders/lifecycle-loader.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024-present, the hapjs-platform Project Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { parseLifecycle } from '@hap-toolkit/compiler'
+
+export default function lifecycleLoader(source) {
+  let lifecycleStr = ''
+  try {
+    const obj = JSON.parse(source)
+    const jsonObj = obj.lifecycle || {}
+    const { parsed } = parseLifecycle(jsonObj)
+    lifecycleStr = parsed
+  } catch (e) {
+    throw new Error(`${this.resourcePath} 中的 <data> 解析失败，请检查是否为标准的 JSON 格式\n${e}`)
+  }
+  return `module.exports = ${lifecycleStr}`
+}

--- a/packages/hap-dsl-xvm/src/loaders/template-loader.js
+++ b/packages/hap-dsl-xvm/src/loaders/template-loader.js
@@ -20,6 +20,13 @@ export default function templateLoader(source) {
 
   if (log && log.length) {
     logWarn(this, log)
+    // 模板编译中的致命错误需要上报为 webpack 编译错误，以中断构建并使进程非零退出
+    log.forEach((item) => {
+      if (item.fatal) {
+        const locationInfo = item.line && item.column ? ` @${item.line}:${item.column}` : ''
+        this.emitError(new Error(`${this.resourcePath}${locationInfo} ${item.reason}`))
+      }
+    })
   }
   depFiles.forEach((file) => {
     let fileName = file

--- a/packages/hap-dsl-xvm/src/loaders/update-loader.js
+++ b/packages/hap-dsl-xvm/src/loaders/update-loader.js
@@ -4,15 +4,15 @@
  */
 import { parseLifecycle } from '@hap-toolkit/compiler'
 
-export default function lifecycleLoader(source) {
-  let lifecycleStr = ''
+export default function updateLoader(source) {
+  let updateStr = ''
   try {
     const obj = JSON.parse(source)
-    const jsonObj = obj.lifecycle || {}
+    const jsonObj = obj.update || {}
     const { parsed } = parseLifecycle(jsonObj)
-    lifecycleStr = parsed
+    updateStr = parsed
   } catch (e) {
     throw new Error(`${this.resourcePath} 中的 <data> 解析失败，请检查是否为标准的 JSON 格式\n${e}`)
   }
-  return `module.exports = ${lifecycleStr}`
+  return `module.exports = ${updateStr}`
 }

--- a/packages/hap-dsl-xvm/src/loaders/ux-fragment-utils.js
+++ b/packages/hap-dsl-xvm/src/loaders/ux-fragment-utils.js
@@ -30,7 +30,8 @@ const defaultLoaders = {
   component: resolveSync('./ux-loader.js'),
   data: resolveSync('./data-loader.js'),
   action: resolveSync('./action-loader.js'),
-  lifecycle: resolveSync('./lifecycle-loader.js'),
+  create: resolveSync('./create-loader.js'),
+  update: resolveSync('./update-loader.js'),
   props: resolveSync('./props-loader.js'),
   fragment: resolveSync('./fragment-loader.js'),
   template: resolveSync('./template-loader.js'),
@@ -124,10 +125,26 @@ function makeLoaderString(type, config, newJSCard, uxType) {
     return stringifyLoaders(loaders)
   }
 
-  if (type === FRAG_TYPE.LIFECYCLE) {
+  if (type === FRAG_TYPE.CREATE) {
     loaders = [
       {
-        name: defaultLoaders.lifecycle
+        name: defaultLoaders.create
+      },
+      {
+        name: defaultLoaders.fragment,
+        query: {
+          index: 0,
+          type: FRAG_TYPE.DATA
+        }
+      }
+    ]
+    return stringifyLoaders(loaders)
+  }
+
+  if (type === FRAG_TYPE.UPDATE) {
+    loaders = [
+      {
+        name: defaultLoaders.update
       },
       {
         name: defaultLoaders.fragment,
@@ -572,13 +589,14 @@ function processActionFrag($loader, datas, uxType) {
 }
 
 /**
- * 处理轻卡<data>片段中lifecycle
+ * 处理轻卡<data>片段中生命周期钩子(create/update)
  * @param $loader
  * @param datas
  * @param uxType
+ * @param {string} fragType - FRAG_TYPE.CREATE 或 FRAG_TYPE.UPDATE
  * @returns {string}
  */
-function processLifecycleFrag($loader, datas, uxType) {
+function processLifecycleFrag($loader, datas, uxType, fragType) {
   let code = 'null'
   if (datas.length) {
     // 有且仅有一个<data>节点
@@ -591,11 +609,25 @@ function processLifecycleFrag($loader, datas, uxType) {
     }
     code = makeRequireString(
       $loader,
-      makeLoaderString(FRAG_TYPE.LIFECYCLE, {}, true, uxType),
+      makeLoaderString(fragType, {}, true, uxType),
       `${src}?index=0&lite=1`
     )
   }
   return code
+}
+
+/**
+ * 处理轻卡<data>片段中 create 钩子
+ */
+function processCreateFrag($loader, datas, uxType) {
+  return processLifecycleFrag($loader, datas, uxType, FRAG_TYPE.CREATE)
+}
+
+/**
+ * 处理轻卡<data>片段中 update 钩子
+ */
+function processUpdateFrag($loader, datas, uxType) {
+  return processLifecycleFrag($loader, datas, uxType, FRAG_TYPE.UPDATE)
 }
 
 /**
@@ -726,7 +758,8 @@ export {
   processScriptFrag,
   processDataFrag,
   processActionFrag,
-  processLifecycleFrag,
+  processCreateFrag,
+  processUpdateFrag,
   processPropsFrag,
   parseImportList,
   // honor process frag

--- a/packages/hap-dsl-xvm/src/loaders/ux-fragment-utils.js
+++ b/packages/hap-dsl-xvm/src/loaders/ux-fragment-utils.js
@@ -30,6 +30,7 @@ const defaultLoaders = {
   component: resolveSync('./ux-loader.js'),
   data: resolveSync('./data-loader.js'),
   action: resolveSync('./action-loader.js'),
+  lifecycle: resolveSync('./lifecycle-loader.js'),
   props: resolveSync('./props-loader.js'),
   fragment: resolveSync('./fragment-loader.js'),
   template: resolveSync('./template-loader.js'),
@@ -111,6 +112,22 @@ function makeLoaderString(type, config, newJSCard, uxType) {
     loaders = [
       {
         name: defaultLoaders.action
+      },
+      {
+        name: defaultLoaders.fragment,
+        query: {
+          index: 0,
+          type: FRAG_TYPE.DATA
+        }
+      }
+    ]
+    return stringifyLoaders(loaders)
+  }
+
+  if (type === FRAG_TYPE.LIFECYCLE) {
+    loaders = [
+      {
+        name: defaultLoaders.lifecycle
       },
       {
         name: defaultLoaders.fragment,
@@ -555,6 +572,33 @@ function processActionFrag($loader, datas, uxType) {
 }
 
 /**
+ * 处理轻卡<data>片段中lifecycle
+ * @param $loader
+ * @param datas
+ * @param uxType
+ * @returns {string}
+ */
+function processLifecycleFrag($loader, datas, uxType) {
+  let code = 'null'
+  if (datas.length) {
+    // 有且仅有一个<data>节点
+    const data = datas[0]
+    // 文件绝对路径
+    let src = $loader.resourcePath
+    const fragAttrsSrc = data.attrs.src
+    if (fragAttrsSrc) {
+      src = fragAttrsSrc
+    }
+    code = makeRequireString(
+      $loader,
+      makeLoaderString(FRAG_TYPE.LIFECYCLE, {}, true, uxType),
+      `${src}?index=0&lite=1`
+    )
+  }
+  return code
+}
+
+/**
  * 处理轻卡自定义组件<data>片段中props
  * @param $loader
  * @param scripts
@@ -682,6 +726,7 @@ export {
   processScriptFrag,
   processDataFrag,
   processActionFrag,
+  processLifecycleFrag,
   processPropsFrag,
   parseImportList,
   // honor process frag

--- a/packages/hap-dsl-xvm/src/loaders/ux-loader.js
+++ b/packages/hap-dsl-xvm/src/loaders/ux-loader.js
@@ -15,7 +15,8 @@ import {
   processScriptFrag,
   processDataFrag,
   processActionFrag,
-  processLifecycleFrag,
+  processCreateFrag,
+  processUpdateFrag,
   processPropsFrag,
   parseImportList,
   // honor process frag
@@ -95,11 +96,17 @@ function assemble($loader, frags, name, queryOptions) {
       uxType,
       FRAG_TYPE.ACTIONS
     )}\n`
-    content += `    $app_module$.exports.lifecycle = ${processLifecycleFrag(
+    content += `    $app_module$.exports.create = ${processCreateFrag(
       $loader,
       frags.data,
       uxType,
-      FRAG_TYPE.LIFECYCLE
+      FRAG_TYPE.CREATE
+    )}\n`
+    content += `    $app_module$.exports.update = ${processUpdateFrag(
+      $loader,
+      frags.data,
+      uxType,
+      FRAG_TYPE.UPDATE
     )}\n`
     content += `    $app_module$.exports.props = ${processPropsFrag(
       $loader,

--- a/packages/hap-dsl-xvm/src/loaders/ux-loader.js
+++ b/packages/hap-dsl-xvm/src/loaders/ux-loader.js
@@ -15,6 +15,7 @@ import {
   processScriptFrag,
   processDataFrag,
   processActionFrag,
+  processLifecycleFrag,
   processPropsFrag,
   parseImportList,
   // honor process frag
@@ -93,6 +94,12 @@ function assemble($loader, frags, name, queryOptions) {
       frags.data,
       uxType,
       FRAG_TYPE.ACTIONS
+    )}\n`
+    content += `    $app_module$.exports.lifecycle = ${processLifecycleFrag(
+      $loader,
+      frags.data,
+      uxType,
+      FRAG_TYPE.LIFECYCLE
     )}\n`
     content += `    $app_module$.exports.props = ${processPropsFrag(
       $loader,

--- a/packages/hap-packager/package.json
+++ b/packages/hap-packager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hap-toolkit/packager",
-  "version": "2.0.9-beta.2",
+  "version": "2.0.9-beta.3",
   "description": "@hap-toolkit/packager",
   "engines": {
     "node": ">=14.0.0"
@@ -44,8 +44,8 @@
     "@babel/traverse": "^7.9.6",
     "@babel/types": "^7.9.6",
     "@hap-toolkit/aaptjs": "^2.0.0",
-    "@hap-toolkit/compiler": "2.0.9-beta.2",
-    "@hap-toolkit/shared-utils": "2.0.9-beta.2",
+    "@hap-toolkit/compiler": "2.0.9-beta.3",
+    "@hap-toolkit/shared-utils": "2.0.9-beta.3",
     "@jayfate/path": "^0.0.13",
     "babel-loader": "^8.1.0",
     "flat": "^5.0.2",

--- a/packages/hap-packager/package.json
+++ b/packages/hap-packager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hap-toolkit/packager",
-  "version": "2.0.9-beta.1",
+  "version": "2.0.9-beta.2",
   "description": "@hap-toolkit/packager",
   "engines": {
     "node": ">=14.0.0"
@@ -44,8 +44,8 @@
     "@babel/traverse": "^7.9.6",
     "@babel/types": "^7.9.6",
     "@hap-toolkit/aaptjs": "^2.0.0",
-    "@hap-toolkit/compiler": "2.0.9-beta.1",
-    "@hap-toolkit/shared-utils": "2.0.9-beta.1",
+    "@hap-toolkit/compiler": "2.0.9-beta.2",
+    "@hap-toolkit/shared-utils": "2.0.9-beta.2",
     "@jayfate/path": "^0.0.13",
     "babel-loader": "^8.1.0",
     "flat": "^5.0.2",

--- a/packages/hap-packager/src/common/constant.js
+++ b/packages/hap-packager/src/common/constant.js
@@ -72,8 +72,12 @@ const LOADER_INFO_LIST = [
     type: 'actions'
   },
   {
-    path: '/lifecycle-loader.js',
-    type: 'lifecycle'
+    path: '/create-loader.js',
+    type: 'create'
+  },
+  {
+    path: '/update-loader.js',
+    type: 'update'
   },
   {
     path: '/props-loader.js',

--- a/packages/hap-packager/src/common/constant.js
+++ b/packages/hap-packager/src/common/constant.js
@@ -72,6 +72,10 @@ const LOADER_INFO_LIST = [
     type: 'actions'
   },
   {
+    path: '/lifecycle-loader.js',
+    type: 'lifecycle'
+  },
+  {
     path: '/props-loader.js',
     type: 'props'
   },

--- a/packages/hap-packager/src/plugins/zip-plugin.js
+++ b/packages/hap-packager/src/plugins/zip-plugin.js
@@ -291,6 +291,13 @@ ZipPlugin.prototype.apply = function (compiler) {
   const options = this.options
 
   compiler.hooks.done.tapAsync('ZipPlugin', async (stats, callback) => {
+    // 编译存在错误时，跳过打包，不生成 rpk/rpks，避免产出有问题的应用包
+    if (stats.compilation.errors && stats.compilation.errors.length) {
+      colorconsole.error('### App Loader ### 编译存在错误，已停止生成应用包')
+      callback()
+      return
+    }
+
     let subpackageOptions = []
     if (!options.disableSubpackages && options.subpackages && options.subpackages.length > 0) {
       subpackageOptions = [...options.subpackages]

--- a/packages/hap-packager/src/post-handler/lite-card-post.js
+++ b/packages/hap-packager/src/post-handler/lite-card-post.js
@@ -12,9 +12,8 @@ const TYPE_IMPORT = 'import'
 // 需要进行后处理的模块key
 const TEMPLATE_KEY = 'template'
 const ACTIONS_KEY = 'actions'
-const LIFECYCLE_KEY = 'lifecycle'
-// lifecycle 支持的钩子
-const LIFECYCLE_HOOKS = ['create', 'update']
+// 生命周期钩子（编译产物中为 #entry 顶层字段）
+const LIFECYCLE_HOOK_KEYS = ['create', 'update']
 
 // 节点标记，同一节点可能同时符合多个kind定义，按priority高的进行标记
 const ENUM_KIND_TYPE = {
@@ -111,19 +110,6 @@ function markParams(actions) {
       delete actions.params[key]
       actions.params['$' + key] = rawExpr
       actions.params['#' + key] = prefixExpr
-    }
-  })
-}
-
-// 处理 lifecycle 中的字段，编译 create/update 的 params 表达式
-// 与 actions params 使用相同的编译规则（复用 markParams）
-function postHandleLifecycle(lifecycle) {
-  if (!isObject(lifecycle)) return
-
-  LIFECYCLE_HOOKS.forEach((hook) => {
-    const hookObj = lifecycle[hook]
-    if (isObject(hookObj)) {
-      markParams(hookObj)
     }
   })
 }
@@ -401,13 +387,16 @@ export function postHandleLiteCardRes(liteCardRes) {
     }
   }
 
-  // lifecycle
+  // 生命周期钩子 create / update（#entry 顶层字段），编译其 params 表达式
+  // 与 actions params 使用相同的编译规则（复用 markParams）
   for (let i = 0; i < uxList.length; i++) {
     const compName = uxList[i]
-    const lifecycle = liteCardRes[compName][LIFECYCLE_KEY]
-    if (lifecycle) {
-      postHandleLifecycle(lifecycle)
-    }
+    LIFECYCLE_HOOK_KEYS.forEach((hookKey) => {
+      const hookObj = liteCardRes[compName][hookKey]
+      if (isObject(hookObj)) {
+        markParams(hookObj)
+      }
+    })
   }
 
   return liteCardRes

--- a/packages/hap-packager/src/post-handler/lite-card-post.js
+++ b/packages/hap-packager/src/post-handler/lite-card-post.js
@@ -12,6 +12,9 @@ const TYPE_IMPORT = 'import'
 // 需要进行后处理的模块key
 const TEMPLATE_KEY = 'template'
 const ACTIONS_KEY = 'actions'
+const LIFECYCLE_KEY = 'lifecycle'
+// lifecycle 支持的钩子
+const LIFECYCLE_HOOKS = ['create', 'update']
 
 // 节点标记，同一节点可能同时符合多个kind定义，按priority高的进行标记
 const ENUM_KIND_TYPE = {
@@ -108,6 +111,19 @@ function markParams(actions) {
       delete actions.params[key]
       actions.params['$' + key] = rawExpr
       actions.params['#' + key] = prefixExpr
+    }
+  })
+}
+
+// 处理 lifecycle 中的字段，编译 create/update 的 params 表达式
+// 与 actions params 使用相同的编译规则（复用 markParams）
+function postHandleLifecycle(lifecycle) {
+  if (!isObject(lifecycle)) return
+
+  LIFECYCLE_HOOKS.forEach((hook) => {
+    const hookObj = lifecycle[hook]
+    if (isObject(hookObj)) {
+      markParams(hookObj)
     }
   })
 }
@@ -382,6 +398,15 @@ export function postHandleLiteCardRes(liteCardRes) {
       Object.keys(actionEvents).forEach((eventName) => {
         postHandleActions(actionEvents[eventName])
       })
+    }
+  }
+
+  // lifecycle
+  for (let i = 0; i < uxList.length; i++) {
+    const compName = uxList[i]
+    const lifecycle = liteCardRes[compName][LIFECYCLE_KEY]
+    if (lifecycle) {
+      postHandleLifecycle(lifecycle)
     }
   }
 

--- a/packages/hap-packager/test/unit/func/__snapshots__/compiler.test.js.snap
+++ b/packages/hap-packager/test/unit/func/__snapshots__/compiler.test.js.snap
@@ -29,7 +29,7 @@ exports[`compile functions replaceModuleImport 4`] = `
     "
 `;
 
-exports[`轻卡 lifecycle params 编译 postHandleLiteCardRes 将 lifecycle params 中的 {{ expr }} 编译为 #/$ AST 1`] = `
+exports[`轻卡 create/update params 编译 postHandleLiteCardRes 将 create/update params 中的 {{ expr }} 编译为 #/$ AST 1`] = `
 Object {
   "#deviceType": Array [
     ".",

--- a/packages/hap-packager/test/unit/func/__snapshots__/compiler.test.js.snap
+++ b/packages/hap-packager/test/unit/func/__snapshots__/compiler.test.js.snap
@@ -28,3 +28,48 @@ exports[`compile functions replaceModuleImport 4`] = `
       const system = $app_require$(\\"@app-module/system\\")
     "
 `;
+
+exports[`轻卡 lifecycle params 编译 postHandleLiteCardRes 将 lifecycle params 中的 {{ expr }} 编译为 #/$ AST 1`] = `
+Object {
+  "#deviceType": Array [
+    ".",
+    Array [
+      ".",
+      Array [
+        "$",
+        "system",
+      ],
+      "device",
+    ],
+    "DEVICE_TYPE",
+  ],
+  "#lat": Array [
+    ".",
+    Array [
+      "()",
+      Array [
+        ".",
+        Array [
+          ".",
+          Array [
+            "$",
+            "system",
+          ],
+          "geolocation",
+        ],
+        "getLocation",
+      ],
+      Array [
+        "{}",
+        Object {
+          "coordType": "gcj02",
+        },
+      ],
+    ],
+    "latitude",
+  ],
+  "$deviceType": "system.device.DEVICE_TYPE",
+  "$lat": "{{ system.geolocation.getLocation({coordType:'gcj02'}).latitude }}",
+  "staticVal": "plain-string",
+}
+`;

--- a/packages/hap-packager/test/unit/func/compiler.test.js
+++ b/packages/hap-packager/test/unit/func/compiler.test.js
@@ -155,11 +155,13 @@ describe('轻卡模板耗时 Feature 编译期校验', () => {
     expect(err.reason).toContain('system.geolocation.getLocation')
     expect(err.reason).toContain('lifecycle.create.params')
     expect(err.line).toBeDefined()
+    // 标记为致命错误，template-loader 据此上报 webpack 错误以中断构建
+    expect(err.fatal).toBe(true)
   })
 
-  it('模板属性表达式中调用 push.subscribe 报错', () => {
+  it('模板属性表达式中调用 service.push.subscribe 报错', () => {
     const res = compileLiteTpl(
-      `<div class="a"><image src="{{ system.push.subscribe().id }}"></image></div>`
+      `<div class="a"><image src="{{ service.push.subscribe().id }}"></image></div>`
     )
     expect(hasForbiddenError(res)).toBe(true)
   })

--- a/packages/hap-packager/test/unit/func/compiler.test.js
+++ b/packages/hap-packager/test/unit/func/compiler.test.js
@@ -4,6 +4,8 @@
  */
 
 const { replaceModuleImport } = require('@hap-toolkit/compiler').scripter
+const { parseLifecycle, parseTemplate } = require('@hap-toolkit/compiler')
+const { postHandleLiteCardRes } = require('../../../lib/post-handler/lite-card-post')
 
 describe('compile functions', () => {
   it('replaceModuleImport', () => {
@@ -30,5 +32,160 @@ describe('compile functions', () => {
 
     expect(requireExp1).toMatchSnapshot()
     expect(requireExp2).toMatchSnapshot()
+  })
+})
+
+/**
+ * 轻卡需求一：lifecycle params 表达式编译
+ * <data> 块中的 lifecycle.create/update.params 中的 {{ expr }} 需要编译为 JSON AST，
+ * 编译规则与 actions params 一致（#key 为 AST，$key 为原文，纯静态值保持原样）。
+ */
+describe('轻卡 lifecycle params 编译', () => {
+  it('parseLifecycle 校验通过并返回合法 JSON', () => {
+    const { parsed } = parseLifecycle({
+      create: {
+        params: {
+          lat: "{{ system.geolocation.getLocation({coordType:'gcj02'}).latitude }}",
+          deviceType: '{{ system.device.DEVICE_TYPE }}'
+        }
+      },
+      update: {
+        params: {
+          deviceType: '{{ system.device.DEVICE_TYPE }}'
+        }
+      }
+    })
+    const obj = JSON.parse(parsed)
+    expect(obj.create.params.lat).toBeDefined()
+    expect(obj.update.params.deviceType).toBeDefined()
+  })
+
+  it('parseLifecycle 拒绝以 $ 开头的 params 参数名', () => {
+    expect(() => {
+      parseLifecycle({ create: { params: { $bad: '{{ a }}' } } })
+    }).toThrow()
+  })
+
+  it('parseLifecycle 拒绝多级结构中绑定变量', () => {
+    expect(() => {
+      parseLifecycle({ create: { params: { obj: { nested: '{{ a }}' } } } })
+    }).toThrow()
+  })
+
+  it('postHandleLiteCardRes 将 lifecycle params 中的 {{ expr }} 编译为 #/$ AST', () => {
+    const liteCardRes = {
+      '#entry': {
+        template: { type: 'div', children: [] },
+        data: { title: 'x' },
+        lifecycle: {
+          create: {
+            params: {
+              lat: "{{ system.geolocation.getLocation({coordType:'gcj02'}).latitude }}",
+              deviceType: '{{ system.device.DEVICE_TYPE }}',
+              staticVal: 'plain-string'
+            }
+          },
+          update: {
+            params: {
+              deviceType: '{{ system.device.DEVICE_TYPE }}'
+            }
+          }
+        }
+      }
+    }
+    const res = postHandleLiteCardRes(liteCardRes)
+    const createParams = res['#entry'].lifecycle.create.params
+
+    // 表达式被编译为 #key(AST) + $key(原文) 对
+    expect(Array.isArray(createParams['#lat'])).toBe(true)
+    expect(createParams['#lat'][0]).toBe('.')
+    expect(createParams).toHaveProperty('$lat')
+    expect(Array.isArray(createParams['#deviceType'])).toBe(true)
+    // 纯静态值保持原样，不加前缀
+    expect(createParams.staticVal).toBe('plain-string')
+    expect(createParams['#staticVal']).toBeUndefined()
+    // update.params 同样被编译
+    expect(Array.isArray(res['#entry'].lifecycle.update.params['#deviceType'])).toBe(true)
+
+    // 记录完整编译产物，锁定 AST 格式
+    expect(createParams).toMatchSnapshot()
+  })
+
+  it('lifecycle 编译不影响 actions / data 的既有行为', () => {
+    const liteCardRes = {
+      '#entry': {
+        template: { type: 'div', children: [] },
+        data: { title: 'x' },
+        actions: {
+          onTap: { type: 'message', params: { d: '{{ system.device.DEVICE_TYPE }}' } }
+        },
+        lifecycle: { create: { params: { a: '{{ system.device.DEVICE_TYPE }}' } } }
+      }
+    }
+    const res = postHandleLiteCardRes(liteCardRes)
+    expect(Array.isArray(res['#entry'].actions.onTap.params['#d'])).toBe(true)
+    expect(res['#entry'].data.title).toBe('x')
+  })
+})
+
+/**
+ * 轻卡需求二：模板中禁止耗时 Feature 调用（编译期校验）
+ * <template> 表达式在 UI 线程同步执行，耗时 Feature（geolocation.getLocation / push.subscribe）
+ * 出现在模板表达式中需编译报错；出现在 lifecycle params / action params 中则放行。
+ */
+describe('轻卡模板耗时 Feature 编译期校验', () => {
+  // parseTemplate 接收的是 <template> 片段内部内容（根为 <div>），不含 <template> 包裹
+  function compileLiteTpl(inner) {
+    return parseTemplate(inner, {
+      uxType: 'card',
+      lite: '1',
+      filePath: '/tmp/liteWidgets/feature_test/index.ux'
+    })
+  }
+  function hasForbiddenError(res) {
+    return res.log.some((l) => /不允许在模板表达式中使用/.test(l.reason || ''))
+  }
+
+  it('模板文本表达式中调用 geolocation.getLocation 报错', () => {
+    const res = compileLiteTpl(
+      `<div><text>{{ system.geolocation.getLocation().latitude }}</text></div>`
+    )
+    expect(hasForbiddenError(res)).toBe(true)
+    const err = res.log.find((l) => /不允许/.test(l.reason))
+    expect(err.reason).toContain('system.geolocation.getLocation')
+    expect(err.reason).toContain('lifecycle.create.params')
+    expect(err.line).toBeDefined()
+  })
+
+  it('模板属性表达式中调用 push.subscribe 报错', () => {
+    const res = compileLiteTpl(
+      `<div class="a"><image src="{{ system.push.subscribe().id }}"></image></div>`
+    )
+    expect(hasForbiddenError(res)).toBe(true)
+  })
+
+  it('模板中非耗时 Feature（system.device）不报错', () => {
+    const res = compileLiteTpl(`<div><text>{{ system.device.DEVICE_TYPE }}</text></div>`)
+    expect(hasForbiddenError(res)).toBe(false)
+  })
+
+  it('模板中 package.hasInstalled 三元表达式不报错', () => {
+    const res = compileLiteTpl(
+      `<div><text>{{ system.package.hasInstalled({package:'com.meituan'}).result ? 'y' : 'n' }}</text></div>`
+    )
+    expect(hasForbiddenError(res)).toBe(false)
+  })
+
+  it('相似但不同路径（foo.system.geolocation.getLocation）不误报', () => {
+    const res = compileLiteTpl(`<div><text>{{ foo.system.geolocation.getLocation() }}</text></div>`)
+    expect(hasForbiddenError(res)).toBe(false)
+  })
+
+  it('lifecycle params 中的耗时 Feature 放行（不经模板校验）', () => {
+    expect(() => {
+      parseLifecycle({
+        create: { params: { lat: '{{ system.geolocation.getLocation().latitude }}' } }
+      })
+    }).not.toThrow()
   })
 })

--- a/packages/hap-packager/test/unit/func/compiler.test.js
+++ b/packages/hap-packager/test/unit/func/compiler.test.js
@@ -36,66 +36,60 @@ describe('compile functions', () => {
 })
 
 /**
- * 轻卡需求一：lifecycle params 表达式编译
- * <data> 块中的 lifecycle.create/update.params 中的 {{ expr }} 需要编译为 JSON AST，
+ * 轻卡需求一：create/update params 表达式编译
+ * <data> 块中的顶层 create/update 的 params 中的 {{ expr }} 需要编译为 JSON AST，
  * 编译规则与 actions params 一致（#key 为 AST，$key 为原文，纯静态值保持原样）。
+ * 编译产出中 create/update 为 #entry 顶层字段（不再包裹 lifecycle 一层）。
  */
-describe('轻卡 lifecycle params 编译', () => {
-  it('parseLifecycle 校验通过并返回合法 JSON', () => {
+describe('轻卡 create/update params 编译', () => {
+  it('parseLifecycle 校验单个钩子并返回合法 JSON', () => {
     const { parsed } = parseLifecycle({
-      create: {
-        params: {
-          lat: "{{ system.geolocation.getLocation({coordType:'gcj02'}).latitude }}",
-          deviceType: '{{ system.device.DEVICE_TYPE }}'
-        }
-      },
-      update: {
-        params: {
-          deviceType: '{{ system.device.DEVICE_TYPE }}'
-        }
+      params: {
+        lat: "{{ system.geolocation.getLocation({coordType:'gcj02'}).latitude }}",
+        deviceType: '{{ system.device.DEVICE_TYPE }}'
       }
     })
     const obj = JSON.parse(parsed)
-    expect(obj.create.params.lat).toBeDefined()
-    expect(obj.update.params.deviceType).toBeDefined()
+    expect(obj.params.lat).toBeDefined()
+    expect(obj.params.deviceType).toBeDefined()
   })
 
   it('parseLifecycle 拒绝以 $ 开头的 params 参数名', () => {
     expect(() => {
-      parseLifecycle({ create: { params: { $bad: '{{ a }}' } } })
+      parseLifecycle({ params: { $bad: '{{ a }}' } })
     }).toThrow()
   })
 
   it('parseLifecycle 拒绝多级结构中绑定变量', () => {
     expect(() => {
-      parseLifecycle({ create: { params: { obj: { nested: '{{ a }}' } } } })
+      parseLifecycle({ params: { obj: { nested: '{{ a }}' } } })
     }).toThrow()
   })
 
-  it('postHandleLiteCardRes 将 lifecycle params 中的 {{ expr }} 编译为 #/$ AST', () => {
+  it('postHandleLiteCardRes 将 create/update params 中的 {{ expr }} 编译为 #/$ AST', () => {
     const liteCardRes = {
       '#entry': {
         template: { type: 'div', children: [] },
         data: { title: 'x' },
-        lifecycle: {
-          create: {
-            params: {
-              lat: "{{ system.geolocation.getLocation({coordType:'gcj02'}).latitude }}",
-              deviceType: '{{ system.device.DEVICE_TYPE }}',
-              staticVal: 'plain-string'
-            }
-          },
-          update: {
-            params: {
-              deviceType: '{{ system.device.DEVICE_TYPE }}'
-            }
+        create: {
+          params: {
+            lat: "{{ system.geolocation.getLocation({coordType:'gcj02'}).latitude }}",
+            deviceType: '{{ system.device.DEVICE_TYPE }}',
+            staticVal: 'plain-string'
+          }
+        },
+        update: {
+          params: {
+            deviceType: '{{ system.device.DEVICE_TYPE }}'
           }
         }
       }
     }
     const res = postHandleLiteCardRes(liteCardRes)
-    const createParams = res['#entry'].lifecycle.create.params
+    const createParams = res['#entry'].create.params
 
+    // create/update 是 #entry 顶层字段，没有 lifecycle 包裹
+    expect(res['#entry'].lifecycle).toBeUndefined()
     // 表达式被编译为 #key(AST) + $key(原文) 对
     expect(Array.isArray(createParams['#lat'])).toBe(true)
     expect(createParams['#lat'][0]).toBe('.')
@@ -105,13 +99,13 @@ describe('轻卡 lifecycle params 编译', () => {
     expect(createParams.staticVal).toBe('plain-string')
     expect(createParams['#staticVal']).toBeUndefined()
     // update.params 同样被编译
-    expect(Array.isArray(res['#entry'].lifecycle.update.params['#deviceType'])).toBe(true)
+    expect(Array.isArray(res['#entry'].update.params['#deviceType'])).toBe(true)
 
     // 记录完整编译产物，锁定 AST 格式
     expect(createParams).toMatchSnapshot()
   })
 
-  it('lifecycle 编译不影响 actions / data 的既有行为', () => {
+  it('create/update 编译不影响 actions / data 的既有行为', () => {
     const liteCardRes = {
       '#entry': {
         template: { type: 'div', children: [] },
@@ -119,7 +113,7 @@ describe('轻卡 lifecycle params 编译', () => {
         actions: {
           onTap: { type: 'message', params: { d: '{{ system.device.DEVICE_TYPE }}' } }
         },
-        lifecycle: { create: { params: { a: '{{ system.device.DEVICE_TYPE }}' } } }
+        create: { params: { a: '{{ system.device.DEVICE_TYPE }}' } }
       }
     }
     const res = postHandleLiteCardRes(liteCardRes)
@@ -131,7 +125,7 @@ describe('轻卡 lifecycle params 编译', () => {
 /**
  * 轻卡需求二：模板中禁止耗时 Feature 调用（编译期校验）
  * <template> 表达式在 UI 线程同步执行，耗时 Feature（geolocation.getLocation / push.subscribe）
- * 出现在模板表达式中需编译报错；出现在 lifecycle params / action params 中则放行。
+ * 出现在模板表达式中需编译报错；出现在 create/update params / action params 中则放行。
  */
 describe('轻卡模板耗时 Feature 编译期校验', () => {
   // parseTemplate 接收的是 <template> 片段内部内容（根为 <div>），不含 <template> 包裹
@@ -153,7 +147,7 @@ describe('轻卡模板耗时 Feature 编译期校验', () => {
     expect(hasForbiddenError(res)).toBe(true)
     const err = res.log.find((l) => /不允许/.test(l.reason))
     expect(err.reason).toContain('system.geolocation.getLocation')
-    expect(err.reason).toContain('lifecycle.create.params')
+    expect(err.reason).toContain('create.params')
     expect(err.line).toBeDefined()
     // 标记为致命错误，template-loader 据此上报 webpack 错误以中断构建
     expect(err.fatal).toBe(true)
@@ -183,11 +177,9 @@ describe('轻卡模板耗时 Feature 编译期校验', () => {
     expect(hasForbiddenError(res)).toBe(false)
   })
 
-  it('lifecycle params 中的耗时 Feature 放行（不经模板校验）', () => {
+  it('create/update params 中的耗时 Feature 放行（不经模板校验）', () => {
     expect(() => {
-      parseLifecycle({
-        create: { params: { lat: '{{ system.geolocation.getLocation().latitude }}' } }
-      })
+      parseLifecycle({ params: { lat: '{{ system.geolocation.getLocation().latitude }}' } })
     }).not.toThrow()
   })
 })

--- a/packages/hap-server/package.json
+++ b/packages/hap-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hap-toolkit/server",
-  "version": "2.0.9-beta.2",
+  "version": "2.0.9-beta.3",
   "description": "hap server",
   "engines": {
     "node": ">=14.0.0"
@@ -26,9 +26,9 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.9.6",
-    "@hap-toolkit/debugger": "2.0.9-beta.2",
-    "@hap-toolkit/packager": "2.0.9-beta.2",
-    "@hap-toolkit/shared-utils": "2.0.9-beta.2",
+    "@hap-toolkit/debugger": "2.0.9-beta.3",
+    "@hap-toolkit/packager": "2.0.9-beta.3",
+    "@hap-toolkit/shared-utils": "2.0.9-beta.3",
     "@jayfate/path": "^0.0.13",
     "crypto-js": "^4.1.1",
     "fs-extra": "^10.0.0",

--- a/packages/hap-server/package.json
+++ b/packages/hap-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hap-toolkit/server",
-  "version": "2.0.9-beta.1",
+  "version": "2.0.9-beta.2",
   "description": "hap server",
   "engines": {
     "node": ">=14.0.0"
@@ -26,9 +26,9 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.9.6",
-    "@hap-toolkit/debugger": "2.0.9-beta.1",
-    "@hap-toolkit/packager": "2.0.9-beta.1",
-    "@hap-toolkit/shared-utils": "2.0.9-beta.1",
+    "@hap-toolkit/debugger": "2.0.9-beta.2",
+    "@hap-toolkit/packager": "2.0.9-beta.2",
+    "@hap-toolkit/shared-utils": "2.0.9-beta.2",
     "@jayfate/path": "^0.0.13",
     "crypto-js": "^4.1.1",
     "fs-extra": "^10.0.0",

--- a/packages/hap-shared-utils/package.json
+++ b/packages/hap-shared-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hap-toolkit/shared-utils",
-  "version": "2.0.9-beta.1",
+  "version": "2.0.9-beta.2",
   "description": "hap shared utils",
   "engines": {
     "node": ">=14.0.0"

--- a/packages/hap-shared-utils/package.json
+++ b/packages/hap-shared-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hap-toolkit/shared-utils",
-  "version": "2.0.9-beta.2",
+  "version": "2.0.9-beta.3",
   "description": "hap shared utils",
   "engines": {
     "node": ">=14.0.0"

--- a/packages/hap-toolkit/package.json
+++ b/packages/hap-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hap-toolkit",
-  "version": "2.0.9-beta.2",
+  "version": "2.0.9-beta.3",
   "description": "A command line toolkit for developing Quick Apps.",
   "engines": {
     "node": ">=14.0.0"
@@ -16,12 +16,12 @@
     "@babel/preset-env": "^7.9.6",
     "@babel/register": "^7.9.0",
     "@babel/runtime": "^7.9.6",
-    "@hap-toolkit/compiler": "2.0.9-beta.2",
-    "@hap-toolkit/debugger": "2.0.9-beta.2",
-    "@hap-toolkit/dsl-xvm": "2.0.9-beta.2",
-    "@hap-toolkit/packager": "2.0.9-beta.2",
-    "@hap-toolkit/server": "2.0.9-beta.2",
-    "@hap-toolkit/shared-utils": "2.0.9-beta.2",
+    "@hap-toolkit/compiler": "2.0.9-beta.3",
+    "@hap-toolkit/debugger": "2.0.9-beta.3",
+    "@hap-toolkit/dsl-xvm": "2.0.9-beta.3",
+    "@hap-toolkit/packager": "2.0.9-beta.3",
+    "@hap-toolkit/server": "2.0.9-beta.3",
+    "@hap-toolkit/shared-utils": "2.0.9-beta.3",
     "@jayfate/path": "^0.0.13",
     "adb-commander": "^0.1.9",
     "ajv": "^6.12.6",

--- a/packages/hap-toolkit/package.json
+++ b/packages/hap-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hap-toolkit",
-  "version": "2.0.9-beta.1",
+  "version": "2.0.9-beta.2",
   "description": "A command line toolkit for developing Quick Apps.",
   "engines": {
     "node": ">=14.0.0"
@@ -16,12 +16,12 @@
     "@babel/preset-env": "^7.9.6",
     "@babel/register": "^7.9.0",
     "@babel/runtime": "^7.9.6",
-    "@hap-toolkit/compiler": "2.0.9-beta.1",
-    "@hap-toolkit/debugger": "2.0.9-beta.1",
-    "@hap-toolkit/dsl-xvm": "2.0.9-beta.1",
-    "@hap-toolkit/packager": "2.0.9-beta.1",
-    "@hap-toolkit/server": "2.0.9-beta.1",
-    "@hap-toolkit/shared-utils": "2.0.9-beta.1",
+    "@hap-toolkit/compiler": "2.0.9-beta.2",
+    "@hap-toolkit/debugger": "2.0.9-beta.2",
+    "@hap-toolkit/dsl-xvm": "2.0.9-beta.2",
+    "@hap-toolkit/packager": "2.0.9-beta.2",
+    "@hap-toolkit/server": "2.0.9-beta.2",
+    "@hap-toolkit/shared-utils": "2.0.9-beta.2",
     "@jayfate/path": "^0.0.13",
     "adb-commander": "^0.1.9",
     "ajv": "^6.12.6",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-tests",
-  "version": "2.0.9-beta.2",
+  "version": "2.0.9-beta.3",
   "description": "intergration tests",
   "engines": {
     "node": ">=14.0.0"
@@ -18,8 +18,8 @@
   "devDependencies": {
     "del": "^4.1.1",
     "glob": "^7.1.6",
-    "hap-dev-utils": "2.0.9-beta.2",
-    "hap-toolkit": "2.0.9-beta.2",
+    "hap-dev-utils": "2.0.9-beta.3",
+    "hap-toolkit": "2.0.9-beta.3",
     "jest": "^24.9.0",
     "node-fetch": "^2.3.0"
   },

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-tests",
-  "version": "2.0.9-beta.1",
+  "version": "2.0.9-beta.2",
   "description": "intergration tests",
   "engines": {
     "node": ">=14.0.0"
@@ -18,8 +18,8 @@
   "devDependencies": {
     "del": "^4.1.1",
     "glob": "^7.1.6",
-    "hap-dev-utils": "2.0.9-beta.1",
-    "hap-toolkit": "2.0.9-beta.1",
+    "hap-dev-utils": "2.0.9-beta.2",
+    "hap-toolkit": "2.0.9-beta.2",
     "jest": "^24.9.0",
     "node-fetch": "^2.3.0"
   },


### PR DESCRIPTION
## 背景

轻卡 Feature 调用机制需要编译器支持两项能力（详见需求文档）：
1. lifecycle 的 `create.params` / `update.params` 中的 `{{ }}` 表达式需要编译为 JSON AST；
2. 模板表达式在 UI 线程同步执行，耗时 Feature 会阻塞渲染，需在编译期拦截。

## 改动内容

### 需求一（P0）：lifecycle params 表达式编译

现状：编译器只提取 `<data>` 块的 `uiData`（→ `data`）和 `actions`，`lifecycle` 字段被直接丢弃。

本次让 `lifecycle` 复用与 actions params 完全一致的编译规则：

- **hap-compiler**：新增 `lifecycle` 模块（`parseLifecycle`），校验 `create`/`update` 的 params（一级绑定、参数名不能以 `$` 开头），并从入口导出。
- **hap-dsl-xvm**：新增 `lifecycle-loader.js`，接入片段体系（`FRAG_TYPE.LIFECYCLE`、`processLifecycleFrag`、`makeLoaderString` 分支），轻卡在 `assemble()` 中导出 `lifecycle`。
- **hap-packager**：`LOADER_INFO_LIST` 注册 lifecycle loader（组装进 `#entry.lifecycle`）；`postHandleLiteCardRes` 中新增 `postHandleLifecycle`，复用 `markParams` 把 params 里的 `{{ expr }}` 编译为 `#key`(JSON AST) + `$key`(原文) 对，纯静态值保持原样。

编译产出示例：

```json
"lifecycle": {
  "create": {
    "params": {
      "#lat": [".", ["()", [".", [".", ["$","system"], "geolocation"], "getLocation"], ["{}", {"coordType":"gcj02"}]], "latitude"],
      "$lat": "{{ system.geolocation.getLocation({coordType:'gcj02'}).latitude }}"
    }
  }
}
```
### 需求二（P1）：模板中禁止耗时 Feature 调用

- 在 hap-compiler 模板校验中新增黑名单（system.geolocation.getLocation、system.push.subscribe），traverse() 对模板属性与文本表达式做检测。
- 命中模板表达式 → 编译报错（含文件/行号、原因与修改建议）；lifecycle params / action params 走独立编译路径，天然放行。

### 测试
- 在 packages/hap-packager/test/unit/func/compiler.test.js 补充 11 个用例，覆盖：lifecycle 校验与 AST 编译（含 snapshot 锁定格式）、静态值保留、actions/data 不受影响、模板耗时 Feature 报错、普通 Feature/相似路径不误报、params 放行。
- 全量回归：hap-packager + hap-dsl-xvm 共 13 套件、40 用例、795 快照全部通过；eslint / prettier 通过。

### 影响范围
- 现有 uiData / actions 编译行为不变（TestCard 等既有快照零改动）。
- 仅轻卡（lite）路径新增 lifecycle 处理与模板校验。